### PR TITLE
Fix docker image, include version in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 /.idea/*
 deafrica.egg-info
+deafrica/_version.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,24 @@ FROM osgeo/gdal:ubuntu-small-3.3.2
 
 RUN apt-get update \
     && apt-get install -y \
+    # Build tools
     build-essential \
     git \
     python3-pip \
     # For Psycopg2
-    libpq-dev python-dev \
+    libpq-dev python3-dev \
+    # For SSL
+    ca-certificates \
     && apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
 
 COPY requirements.txt /tmp/
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r /tmp/requirements.txt
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    --no-binary rasterio \
+    --no-binary shapely \
+    --no-binary fiona
 
 RUN mkdir -p /code
 WORKDIR /code


### PR DESCRIPTION
* Updates ca-certificates to resolve SSL issue
* Ignores the _version.py file
* Also adds key geospatial libraries to no-binary so they are built