### PR TITLE
Cleanup chirps to make errors cleaner

### DIFF
--- a/deafrica/data/chirps.py
+++ b/deafrica/data/chirps.py
@@ -76,9 +76,14 @@ def download_and_cog_chirps(
         in_href = MONTHLY_URL_TEMPLATE.format(in_file=in_file)
         in_data = f"/vsigzip//vsicurl/{in_href}"
         if not check_for_url_existence(in_href):
+            log.warning("Couldn't find the gzipped file, trying the .tif")
             in_file = f"chirps-v2.0.{year}.{month}.tif"
             in_href = MONTHLY_URL_TEMPLATE.format(in_file=in_file)
             in_data = f"/vsicurl/{in_href}"
+
+            if not check_for_url_existence(in_href):
+                log.error("Couldn't find the .tif file either, aborting")
+                sys.exit(1)
 
         file_base = f"{s3_dst}/chirps-v2.0_{year}.{month}"
         out_data = f"{file_base}.tif"

--- a/deafrica/data/chirps.py
+++ b/deafrica/data/chirps.py
@@ -6,8 +6,7 @@ from datetime import datetime
 import click
 import pystac
 import requests
-from deafrica.utils import (odc_uuid, send_slack_notification, setup_logging,
-                            slack_url)
+from deafrica.utils import odc_uuid, send_slack_notification, setup_logging, slack_url
 from odc.aws import s3_dump, s3_head_object
 from pystac.utils import datetime_to_str
 from rasterio.io import MemoryFile

--- a/deafrica/data/chirps.py
+++ b/deafrica/data/chirps.py
@@ -28,7 +28,7 @@ log.info("Starting CHIRPS downloader")
 def check_for_url_existence(href):
     response = requests.head(href)
     try:
-        requests.raise_for_status(response)
+        response.raise_for_status()
     except requests.exceptions.HTTPError:
         log.error(f"{href} returned {response.status_code}")
         return False


### PR DESCRIPTION
* Handle HTTP errors better
* Check for .tif.gz as well as .tif before proceeding
* Exit early if neither .tif.gz nor .tif exist