### PR TITLE
Add odc tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -300,5 +300,8 @@ xarray==0.21.0
 zict==2.0.0
     # via distributed
 
+--extra-index-url https://packages.dea.ga.gov.au/
+odc-apps-dc-tools==0.2.5.dev3356
+
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ console_scripts =
     download-cop-gls = deafrica.data.copernicus_gls:cli
     download-cop-cci = deafrica.data.copernicus_cci:cli
     delete-sandbox-volumes = deafrica.platform.sandbox_volume_cleanup:cli
+    stac-to-dc = odc.apps.dc_tools.stac_api_to_dc:cli
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ install_requires =
     odc-cloud
     odc-stac
     pandas
-    pystac
+    pystac>=1.0.0
+    pystac-client>=0.2.0
     rasterio
     requests
     rio_cogeo


### PR DESCRIPTION
Hi @mmukwevho please review these changes needed to include the "odc-apps-dc-tools" packages (by GA) in the deafrica-scripts docker image. These tools allow indexing of STAC collections to the ODC (via the stac-to-dc command line interface), commonly used to index STAC compliant data collections.