### PR TITLE
Fix volume cleanup

### DIFF
--- a/deafrica/platform/sandbox_volume_cleanup.py
+++ b/deafrica/platform/sandbox_volume_cleanup.py
@@ -17,7 +17,7 @@ log = setup_logging()
 def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
     Cleanup sandbox unused Volumes, k8s PVs & PVCs by
-    looking into CloudTrail "AttachVolume" events over the past 90 days
+    looking into CloudTrail "AttachVolume and "DetachVolume" events over the past 90 days
     """
     # configure kubernetes API client
     try:
@@ -49,17 +49,18 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
             ],
         },
     ]
+    
     del_count = 0
     ignore_count = 0
     fail_count = 0
 
     if tojson:
-        jsondata = [] # array to store data to write
+        jsondata = [] # array to store data to write file
 
     log.info(f'dryrun : {dryrun}')
     for volume in ec2_resource.volumes.filter(Filters=filters):
         # cloud logs only go back 90 days. 
-        # call last 90 days explicitly incase a change is made
+        # call last 90 days explicitly incase this changes
         response = ct_client.lookup_events(
             LookupAttributes=[
                 {"AttributeKey": "ResourceName", "AttributeValue": volume.id},
@@ -69,23 +70,24 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
             EndTime=time_now,
         )
 
+        # check both attach and detach events
         attach_events = [
             event
             for event in response["Events"]
-            if event.get("EventName") == "AttachVolume"
+            if event.get("EventName") in ["AttachVolume","DetachVolume"]
         ]
 
         try:
             # collect some properties
             pv_name, pvc_name = get_user_claim(volume)
             props = {
-                    'action' : None, # either DELETE, DRY_RUN_DELETE, IGNORE
+                    'action' : None, # set below, one of [DELETE, DRY_RUN_DELETE, IGNORE]
                     'volume_id' : volume.id,
                     'volume_size' : volume.size,
                     'volume_state' : volume.state,
                     'volume_created' : volume.create_time.strftime("%Y/%m/%d, %H:%M:%S"),
-                    'volume_last_attached' : None, # None implies > 90 days, if logs exist replaced below
-                    'volume_last_attached_days' : None,
+                    'volume_last_attach_detach' : None, # None implies > 90 days. Replaced below if logs exist
+                    'volume_last_attach_detach_days' : None,
                     'pv_name' : pv_name,
                     'pvc_name' : pvc_name,
             }
@@ -95,14 +97,15 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
                 # no attachments in last 90 days and ebs is not in use
                 props['action'] = 'DELETE' if not dryrun else 'DRY_RUN_DELETE'
                 log.info(log_string(props))
-                delete(dryrun, k8s_api, namespace, volume, props)
+                if not dryrun:
+                    delete(k8s_api, namespace, volume, props)
                 del_count += 1
             
             else:
                 # attachments in last 90d or ebs in use
                 props['action'] = 'IGNORE'
-                props['volume_last_attached'] = attach_events[0]['EventTime'].strftime("%Y/%m/%d, %H:%M:%S")
-                props['volume_last_attached_days'] = abs(attach_events[0]['EventTime'].replace(tzinfo=None) - time_now).days
+                props['volume_last_attach_detach'] = attach_events[0]['EventTime'].strftime("%Y/%m/%d, %H:%M:%S")
+                props['volume_last_attach_detach_days'] = abs(attach_events[0]['EventTime'].replace(tzinfo=None) - time_now).days
                 log.info(log_string(props))
                 ignore_count += 1
         
@@ -127,41 +130,40 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
         with open(tojson, "w") as outfile: 
             json.dump(jsondata, outfile)
 
-def delete(dryrun, k8s_api, namespace, volume, props):
-    if not dryrun:
-        # cleanup k8s PVC/PV
-        if (
-            len(
-                [
-                    pvc
-                    for pvc in k8s_api.list_namespaced_persistent_volume_claim(
-                        namespace
-                    ).items
-                    if pvc.spec.volume_name == props['pv_name']
-                ]
-            )
-            > 0
-        ):
-            log.info(f"Delete PVC: {props['pvc_name']}")
-            k8s_api.delete_namespaced_persistent_volume_claim(props['pvc_name'], namespace)
-        if (
-            len(
-                [
-                    pv
-                    for pv in k8s_api.list_persistent_volume().items
-                    if pv.metadata.name == props['pv_name']
-                ]
-            )
-            > 0
-        ):
-            log.info(f"Delete PV: {props['pv_name']}")
-            k8s_api.delete_persistent_volume(props['pv_name'])
+def delete(k8s_api, namespace, volume, props):
+    # cleanup k8s PVC/PV
+    if (
+        len(
+            [
+                pvc
+                for pvc in k8s_api.list_namespaced_persistent_volume_claim(
+                    namespace
+                ).items
+                if pvc.spec.volume_name == props['pv_name']
+            ]
+        )
+        > 0
+    ):
+        log.info(f"Delete PVC: {props['pvc_name']}")
+        k8s_api.delete_namespaced_persistent_volume_claim(props['pvc_name'], namespace)
+    if (
+        len(
+            [
+                pv
+                for pv in k8s_api.list_persistent_volume().items
+                if pv.metadata.name == props['pv_name']
+            ]
+        )
+        > 0
+    ):
+        log.info(f"Delete PV: {props['pv_name']}")
+        k8s_api.delete_persistent_volume(props['pv_name'])
 
-        # cleanup volume
-        # NOTE: k8s ebs storageclass volume reclaimPolicy:retain so explicit cleanup required
-        log.info(f"Delete volume: {volume.id}")
-        volume.delete()
-        log.info("Deletion Completed Successfully")
+    # cleanup volume
+    # NOTE: k8s ebs storageclass volume reclaimPolicy:retain so explicit cleanup required
+    log.info(f"Delete volume: {volume.id}")
+    volume.delete()
+    log.info("Deletion Completed Successfully")
 
 def get_user_claim(volume):
     pvc_name = ""
@@ -215,5 +217,5 @@ def cli(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
     delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson)
 
-if __name__ == "__main__":
-    cli()
+# if __name__ == "__main__":
+#     cli()

--- a/deafrica/platform/sandbox_volume_cleanup.py
+++ b/deafrica/platform/sandbox_volume_cleanup.py
@@ -14,6 +14,7 @@ log = setup_logging()
 # log = logging.getLogger()
 # logging.basicConfig(level=logging.INFO)
 
+
 def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
     Cleanup sandbox unused Volumes, k8s PVs & PVCs by
@@ -49,17 +50,17 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
             ],
         },
     ]
-    
+
     del_count = 0
     ignore_count = 0
     fail_count = 0
 
     if tojson:
-        jsondata = [] # array to store data to write file
+        jsondata = []  # array to store data to write file
 
-    log.info(f'dryrun : {dryrun}')
+    log.info(f"dryrun : {dryrun}")
     for volume in ec2_resource.volumes.filter(Filters=filters):
-        # cloud logs only go back 90 days. 
+        # cloud logs only go back 90 days.
         # call last 90 days explicitly incase this changes
         response = ct_client.lookup_events(
             LookupAttributes=[
@@ -74,46 +75,50 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
         attach_events = [
             event
             for event in response["Events"]
-            if event.get("EventName") in ["AttachVolume","DetachVolume"]
+            if event.get("EventName") in ["AttachVolume", "DetachVolume"]
         ]
 
         try:
             # collect some properties
             pv_name, pvc_name = get_user_claim(volume)
             props = {
-                    'action' : None, # set below, one of [DELETE, DRY_RUN_DELETE, IGNORE]
-                    'volume_id' : volume.id,
-                    'volume_size' : volume.size,
-                    'volume_state' : volume.state,
-                    'volume_created' : volume.create_time.strftime("%Y/%m/%d, %H:%M:%S"),
-                    'volume_last_attach_detach' : None, # None implies > 90 days. Replaced below if logs exist
-                    'volume_last_attach_detach_days' : None,
-                    'pv_name' : pv_name,
-                    'pvc_name' : pvc_name,
+                "action": None,  # set below, one of [DELETE, DRY_RUN_DELETE, IGNORE]
+                "volume_id": volume.id,
+                "volume_size": volume.size,
+                "volume_state": volume.state,
+                "volume_created": volume.create_time.strftime("%Y/%m/%d, %H:%M:%S"),
+                "volume_last_attach_detach": None,  # None implies > 90 days. Replaced below if logs exist
+                "volume_last_attach_detach_days": None,
+                "pv_name": pv_name,
+                "pvc_name": pvc_name,
             }
 
             # Cleanup Volume, k8s PV & PVC
             if len(attach_events) == 0 and volume.state == "available":
                 # no attachments in last 90 days and ebs is not in use
-                props['action'] = 'DELETE' if not dryrun else 'DRY_RUN_DELETE'
+                props["action"] = "DELETE" if not dryrun else "DRY_RUN_DELETE"
                 log.info(log_string(props))
                 if not dryrun:
                     delete(k8s_api, namespace, volume, props)
                 del_count += 1
-            
+
             else:
                 # attachments in last 90d or ebs in use
-                props['action'] = 'IGNORE'
-                props['volume_last_attach_detach'] = attach_events[0]['EventTime'].strftime("%Y/%m/%d, %H:%M:%S")
-                props['volume_last_attach_detach_days'] = abs(attach_events[0]['EventTime'].replace(tzinfo=None) - time_now).days
+                props["action"] = "IGNORE"
+                props["volume_last_attach_detach"] = attach_events[0][
+                    "EventTime"
+                ].strftime("%Y/%m/%d, %H:%M:%S")
+                props["volume_last_attach_detach_days"] = abs(
+                    attach_events[0]["EventTime"].replace(tzinfo=None) - time_now
+                ).days
                 log.info(log_string(props))
                 ignore_count += 1
-        
+
         except Exception as e:
-            props['action'] = 'FAILED_TO_DELETE'
+            props["action"] = "FAILED_TO_DELETE"
             log.warning(log_string(props))
             log.exception(e)
-            fail_count +=1
+            fail_count += 1
             pass
 
         if tojson:
@@ -124,11 +129,12 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
     log.info(f"Total Volumes Deleted -> {del_count}")
     log.info(f"Total Volumes Ignored -> {ignore_count}")
     log.info(f"Total Failed Volume Deletion -> {fail_count}")
-    
+
     if tojson:
         log.info(f"Saving output to {tojson}")
-        with open(tojson, "w") as outfile: 
+        with open(tojson, "w") as outfile:
             json.dump(jsondata, outfile)
+
 
 def delete(k8s_api, namespace, volume, props):
     # cleanup k8s PVC/PV
@@ -139,31 +145,32 @@ def delete(k8s_api, namespace, volume, props):
                 for pvc in k8s_api.list_namespaced_persistent_volume_claim(
                     namespace
                 ).items
-                if pvc.spec.volume_name == props['pv_name']
+                if pvc.spec.volume_name == props["pv_name"]
             ]
         )
         > 0
     ):
         log.info(f"Delete PVC: {props['pvc_name']}")
-        k8s_api.delete_namespaced_persistent_volume_claim(props['pvc_name'], namespace)
+        k8s_api.delete_namespaced_persistent_volume_claim(props["pvc_name"], namespace)
     if (
         len(
             [
                 pv
                 for pv in k8s_api.list_persistent_volume().items
-                if pv.metadata.name == props['pv_name']
+                if pv.metadata.name == props["pv_name"]
             ]
         )
         > 0
     ):
         log.info(f"Delete PV: {props['pv_name']}")
-        k8s_api.delete_persistent_volume(props['pv_name'])
+        k8s_api.delete_persistent_volume(props["pv_name"])
 
     # cleanup volume
     # NOTE: k8s ebs storageclass volume reclaimPolicy:retain so explicit cleanup required
     log.info(f"Delete volume: {volume.id}")
     volume.delete()
     log.info("Deletion Completed Successfully")
+
 
 def get_user_claim(volume):
     pvc_name = ""
@@ -175,13 +182,15 @@ def get_user_claim(volume):
             pv_name = tags["Value"]
     return pv_name, pvc_name
 
+
 def log_string(props):
     """
     create a string to print for logging
     """
     keys = sorted(props.keys())
-    print_str = "".join([f'{key} : {props[key]}, ' for key in keys])
+    print_str = "".join([f"{key} : {props[key]}, " for key in keys])
     return print_str
+
 
 @click.command("delete-sandbox-volumes")
 @click.option(
@@ -203,19 +212,19 @@ def log_string(props):
         The filter is run on ebs tag:kubernetes.io/created-for/pvc/name.
         e.g. claim-alex-2ebradley-* will limit the volume search to such strings.
         useful for testing on specific volumes. 
-        """
+        """,
 )
 @click.option(
     "--tojson",
-    default='',
+    default="",
     help="Name of .json file for debug. Write ebs actions to a json file.",
 )
-
 def cli(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
     Delete sandbox unused volumes using CloudTrail events
     """
     delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson)
+
 
 # if __name__ == "__main__":
 #     cli()

--- a/deafrica/platform/sandbox_volume_cleanup.py
+++ b/deafrica/platform/sandbox_volume_cleanup.py
@@ -9,11 +9,6 @@ from deafrica.utils import setup_logging
 
 log = setup_logging()
 
-# local testing
-# import logging
-# log = logging.getLogger()
-# logging.basicConfig(level=logging.INFO)
-
 
 def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
@@ -224,7 +219,3 @@ def cli(namespace, dryrun, ebs_tag_filter_debug, tojson):
     Delete sandbox unused volumes using CloudTrail events
     """
     delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson)
-
-
-# if __name__ == "__main__":
-#     cli()

--- a/deafrica/platform/sandbox_volume_cleanup.py
+++ b/deafrica/platform/sandbox_volume_cleanup.py
@@ -3,15 +3,16 @@ import click as click
 from datetime import datetime
 from datetime import timedelta
 import json
-import logging
 from kubernetes import config, client
 
-#from deafrica.utils import setup_logging
+from deafrica.utils import setup_logging
 
-# Set log level to info
-#log = setup_logging()
-log = logging.getLogger()
-logging.basicConfig(level=logging.INFO)
+log = setup_logging()
+
+# local testing
+# import logging
+# log = logging.getLogger()
+# logging.basicConfig(level=logging.INFO)
 
 def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """

--- a/deafrica/platform/sandbox_volume_cleanup.py
+++ b/deafrica/platform/sandbox_volume_cleanup.py
@@ -58,7 +58,8 @@ def delete_volumes(namespace, dryrun, ebs_tag_filter_debug, tojson):
 
     log.info(f'dryrun : {dryrun}')
     for volume in ec2_resource.volumes.filter(Filters=filters):
-        # cloud logs only go back 90 days
+        # cloud logs only go back 90 days. 
+        # call last 90 days explicitly incase a change is made
         response = ct_client.lookup_events(
             LookupAttributes=[
                 {"AttributeKey": "ResourceName", "AttributeValue": volume.id},
@@ -187,6 +188,11 @@ def log_string(props):
     help="Provide a namespace. default sandbox",
 )
 @click.option(
+    "--dryrun",
+    is_flag=True,
+    help="Do not run delete, just print the action",
+)
+@click.option(
     "--ebs-tag-filter-debug",
     default="*",
     help="""
@@ -202,11 +208,7 @@ def log_string(props):
     default='',
     help="Name of .json file for debug. Write ebs actions to a json file.",
 )
-@click.option(
-    "--dryrun",
-    is_flag=True,
-    help="Do not run delete, just print the action",
-)
+
 def cli(namespace, dryrun, ebs_tag_filter_debug, tojson):
     """
     Delete sandbox unused volumes using CloudTrail events

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-moto
+moto==4.2.14
 pytest
 pytest-cov
 pytest-httpserver


### PR DESCRIPTION
Fixing broken volume cleanup script. [An update to the ebs_csi_driver ](https://github.com/digitalearthafrica/deafrica-scripts/assets/55119000/d9f54878-4291-4b71-a2c0-c669db5e62e1) caused the original script to break. This caused the filter being applied to the volume tags to fail, meaning no ebs volumes were considered for deletion. The volume filter has been updated, and additional comments and arguments for testing have been added. 