### PR TITLE
Warn email sandbox users

### DIFF
--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -103,16 +103,16 @@ def send_warning_email(
             "Body": {
                 "Html": {
                     "Charset": "utf-8",
-                    "Data": f"Good Day. \n Your{env_str1}Digital Earth Africa Sandbox Volume will be eligible for deletion in {days_to_delete} days! Please login to your DE Africa Sandbox{env_str2}to prevent your data being lost.",
+                    "Data": f"Good Day. \n Your{env_str1}Digital Earth Africa Sandbox Volume will be scheduled for deletion in {days_to_delete} days! Please login to your DE Africa Sandbox{env_str2}to prevent your data being lost.",
                 },
                 "Text": {
                     "Charset": "utf-8",
-                    "Data": f"Good Day. \n Your{env_str1}Digital Earth Africa Sandbox  Volume will be eligible for deletion in {days_to_delete} days! Please login to your DE Africa Sandbox{env_str2}to prevent your data being lost.",
+                    "Data": f"Good Day. \n Your{env_str1}Digital Earth Africa Sandbox  Volume will be scheduled for deletion in {days_to_delete} days! Please login to your DE Africa Sandbox{env_str2}to prevent your data being lost.",
                 },
             },
             "Subject": {
                 "Charset": "utf-8",
-                "Data": f"Warning - Your{env_str1}Digital Earth Africa Sandbox Volume will be eligible for deletion in {days_to_delete} days!",
+                "Data": f"Warning - Your{env_str1}Digital Earth Africa Sandbox Volume will be scheduled for deletion in {days_to_delete} days!",
             },
         },
         Source=SourceAdress,

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -203,8 +203,8 @@ def warn_unused_sandbox_volumes(cluster_name, cron_schedule, dryrun):
             else timedelta(days=0)
         )
 
-        # note, the deletion script is currently run monthly so the volumes
-        # may actually last longer than the warning states. hence warning acts as a minimum
+        # note, the deletion script may be run on a different schedule (e.g. monthly)
+        # volumes will therefore last longer than the warning states. hence warning acts as a minimum
         if cron_schedule == "daily":
             # emails are being sent daily, therefore we collect users with exactly
             # 5 and 30 days until deletion

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -119,9 +119,9 @@ def send_warning_email(
     )
 
     if int(response["ResponseMetadata"]["HTTPStatusCode"]) != 200:
-        raise HTTPError("HTTP response is not 200")
+        raise HTTPError(f"{days_to_delete} day warning email failed to send")
     else:
-        log.info(f"{days_to_delete} day warning email successfully send")
+        log.info(f"{days_to_delete} day warning email successfully sent")
 
 
 def warn_unused_sandbox_volumes(cluster_name, cron_schedule, dryrun):

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -79,7 +79,7 @@ def send_warning_email(
     BccAddresses,
     CcAddresses=[],
     ToAddresses=[],
-    SourceAdress="systems@digitalearthafrica.org",
+    SourceAdress="info@digitalearthafrica.org",
 ):
     """
     send an email warning for impending deletion.
@@ -245,11 +245,15 @@ def warn_unused_sandbox_volumes(cluster_name, cron_schedule, dryrun):
             for user in volume_warnings
             if user["action"] == "5 Day Warning"
         ]
-        log.info("Users receiving 5 day warning emails")
-        log.info(five_day_emails)
-        send_warning_email(
-            ses_client, cluster_name, days_to_delete=5, BccAddresses=five_day_emails
-        )
+
+        if len(five_day_emails) > 0:
+            log.info("Users receiving 5 day warning emails")
+            log.info(five_day_emails)
+            send_warning_email(
+                ses_client, cluster_name, days_to_delete=5, BccAddresses=five_day_emails
+            )
+        else:
+            log.info("No 5 Day Warnings required for users")
 
         # send a 30 day warning to uesers
         thirty_day_emails = [
@@ -257,11 +261,18 @@ def warn_unused_sandbox_volumes(cluster_name, cron_schedule, dryrun):
             for user in volume_warnings
             if user["action"] == "30 Day Warning"
         ]
-        log.info("Users receiving 30 day warning emails")
-        log.info(thirty_day_emails)
-        send_warning_email(
-            ses_client, cluster_name, days_to_delete=30, BccAddresses=thirty_day_emails
-        )
+
+        if len(thirty_day_emails) > 0:
+            log.info("Users receiving 30 day warning emails")
+            log.info(thirty_day_emails)
+            send_warning_email(
+                ses_client,
+                cluster_name,
+                days_to_delete=30,
+                BccAddresses=thirty_day_emails,
+            )
+        else:
+            log.info("No 30 Day Warnings required for users")
 
 
 @click.command("warn-unused-volumes")

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -93,7 +93,6 @@ def send_warning_email(
         env_str1 = " Internal Development "
         env_str2 = " at https://sandbox.dev.digitalearth.africa "
 
-    # fmt: off
     response = ses_client.send_email(
         Destination={
             "BccAddresses": BccAddresses,
@@ -118,7 +117,6 @@ def send_warning_email(
         },
         Source=SourceAdress,
     )
-    # fmt: on
 
     if int(response["ResponseMetadata"]["HTTPStatusCode"]) != 200:
         raise HTTPError("HTTP response is not 200")

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -93,6 +93,7 @@ def send_warning_email(
         env_str1 = " Internal Development "
         env_str2 = " at https://sandbox.dev.digitalearth.africa "
 
+    # fmt: off
     response = ses_client.send_email(
         Destination={
             "BccAddresses": BccAddresses,
@@ -117,6 +118,7 @@ def send_warning_email(
         },
         Source=SourceAdress,
     )
+    # fmt: on
 
     if int(response["ResponseMetadata"]["HTTPStatusCode"]) != 200:
         raise HTTPError("HTTP response is not 200")

--- a/deafrica/platform/warn_unused_sandbox_volumes.py
+++ b/deafrica/platform/warn_unused_sandbox_volumes.py
@@ -90,7 +90,7 @@ def send_warning_email(
         env_str2 = " "
     elif cluster_name == "deafrica-dev-eks":
         # add strings for the development server for internal users
-        env_str1 = " Development "
+        env_str1 = " Internal Development "
         env_str2 = " at https://sandbox.dev.digitalearth.africa "
 
     response = ses_client.send_email(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "deafrica/_version.py"
+
+[tool.black]
+exclude = "deafrica/platform/warn_unused_sandbox_volumes.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ console_scripts =
     download-cop-gls = deafrica.data.copernicus_gls:cli
     download-cop-cci = deafrica.data.copernicus_cci:cli
     delete-sandbox-volumes = deafrica.platform.sandbox_volume_cleanup:cli
-    warn-unused-volumes = deafrica.platform.warn_sandbox_unused_volumes:cli
+    warn-unused-sandbox-volumes = deafrica.platform.warn_unused_sandbox_volumes:cli
     download-wsf = deafrica.data.wsf:cli
 
 [options.packages.find]


### PR DESCRIPTION
Fixing the script for emailing users who's sandbox volumes will be deleted. Warnings are made twice, first when the volume will be deleted in 30 days and second when the volume will be deleted in 5 days. The script is designed to run on a daily (preferred) or weekly cron job. This is a cl argument (cron-schedule) as it changes the logic for warning users. 

Different warnings are given for volumes in the dev (internal) and prod clusters (public users).

