### PR TITLE
S2 gap filler fix

### DIFF
--- a/deafrica/monitoring/s2_gap_filler.py
+++ b/deafrica/monitoring/s2_gap_filler.py
@@ -31,8 +31,10 @@ SOURCE_REGION = "us-west-2"
 S3_BUCKET_PATH = "s3://deafrica-sentinel-2/status-report/"
 
 import warnings
+
 # supress a FutureWarning from pyproj
-warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
 
 def get_cog_shape_transform(cog_url: str):
     """get the shape and transform of a cog
@@ -121,11 +123,11 @@ def prepare_s2_l2a_stac(src_stac_doc: Dict):
     """
 
     # change the properties to align with original sqs message
-    # read in the tileinfo.json file and create a STAC document 
+    # read in the tileinfo.json file and create a STAC document
     # based off of this using the sentinel_s2_l2a package
-    # this will form the basis of our SNS message body as it is 
+    # this will form the basis of our SNS message body as it is
     # most closely aligned with the original message
-    if 'tileinfo_metadata' in list(src_stac_doc["assets"].keys()):
+    if "tileinfo_metadata" in list(src_stac_doc["assets"].keys()):
         tileinfo_url = src_stac_doc["assets"]["tileinfo_metadata"]["href"]
     else:
         tileinfo_url = src_stac_doc["assets"]["info"]["href"]
@@ -285,8 +287,9 @@ def prepare_message(
             yield message
         except Exception as exc:
             if log:
-                log.error(f'Error generating message for : {s3_path}')
+                log.error(f"Error generating message for : {s3_path}")
                 log.error(f"{exc}")
+
 
 def send_messages(
     idx: int,

--- a/deafrica/monitoring/s2_gap_filler.py
+++ b/deafrica/monitoring/s2_gap_filler.py
@@ -194,6 +194,7 @@ def prepare_s2_l2a_stac(src_stac_doc: Dict):
     )
     tileinfo_metadata["assets"]["overview"]["type"] = asset_type
 
+    # TODO this can be removed if fixed by provider
     # fix the shape/transform for the extra bands
     # for whatever reason, these are incorrect in the src_stac_file...
     # code reaches out to cogs for shape and transform

--- a/deafrica/tests/data/sentinel_2/fake_stac.json
+++ b/deafrica/tests/data/sentinel_2/fake_stac.json
@@ -1,29 +1,655 @@
 {
   "type": "Feature",
   "stac_version": "1.0.0-beta.2",
-  "bbox": [
-    -23.82313547199443,
-    17.076994192392323,
-    -22.787666823833955,
-    17.363390699247176
+  "stac_extensions": [
+    "eo",
+    "view",
+    "proj"
   ],
+  "id": "S2B_35QKG_20230603_0_L2A",
+  "bbox": [
+    24.042296606388692,
+    23.394102150517018,
+    25.13839770774511,
+    24.40179704290333
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          24.064750019077884,
+          23.394102150517018
+        ],
+        [
+          24.042296606388692,
+          24.38452626969626
+        ],
+        [
+          25.124142162651808,
+          24.40179704290333
+        ],
+        [
+          25.13839770774511,
+          23.41058780808895
+        ],
+        [
+          24.064750019077884,
+          23.394102150517018
+        ]
+      ]
+    ]
+  },
   "properties": {
-    "datetime": "2018-10-19T12:16:48Z",
-    "platform": "sentinel-2a",
+    "datetime": "2023-06-03T09:03:52Z",
+    "platform": "sentinel-2b",
     "constellation": "sentinel-2",
     "instruments": [
       "msi"
     ],
     "gsd": 10,
     "view:off_nadir": 0,
-    "proj:epsg": 32627,
-    "sentinel:utm_zone": 27,
+    "proj:epsg": 32635,
+    "sentinel:utm_zone": 35,
     "sentinel:latitude_band": "Q",
-    "sentinel:grid_square": "TV",
+    "sentinel:grid_square": "KG",
     "sentinel:sequence": "0",
-    "sentinel:product_id": "S2A_MSIL2A_20181019T121651_N0001_R066_T27QTV_20200308T131556",
-    "sentinel:data_coverage": 15.78,
-    "eo:cloud_cover": 6.09,
-    "sentinel:valid_cloud_cover": true
-  }
+    "sentinel:product_id": "S2B_MSIL2A_20230603T084559_N0509_R107_T35QKG_20230603T115719",
+    "sentinel:data_coverage": 100.0,
+    "eo:cloud_cover": 0.0,
+    "sentinel:valid_cloud_cover": false,
+    "sentinel:processing_baseline": "05.09",
+    "sentinel:boa_offset_applied": true
+  },
+  "collection": "sentinel-s2-l2a-cogs",
+  "assets": {
+    "thumbnail": {
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/35/Q/KG/2023/6/3/0/preview.jpg"
+    },
+    "overview": {
+      "title": "True color image",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "overview"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/L2A_PVI.tif",
+      "proj:shape": [
+        343,
+        343
+      ],
+      "proj:transform": [
+        320.0,
+        0.0,
+        199980.0,
+        0.0,
+        -320.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "info": {
+      "title": "Original JSON metadata",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/35/Q/KG/2023/6/3/0/tileInfo.json"
+    },
+    "metadata": {
+      "title": "Original XML metadata",
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/35/Q/KG/2023/6/3/0/metadata.xml"
+    },
+    "visual": {
+      "title": "True color image",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "overview"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/TCI.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B01": {
+      "title": "Band 1 (coastal)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 60,
+      "eo:bands": [
+        {
+          "name": "B01",
+          "common_name": "coastal",
+          "center_wavelength": 0.4439,
+          "full_width_half_max": 0.027
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B01.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        199980.0,
+        0.0,
+        -60.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B02": {
+      "title": "Band 2 (blue)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.4966,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B02.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B03": {
+      "title": "Band 3 (green)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B03.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B04": {
+      "title": "Band 4 (red)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.6645,
+          "full_width_half_max": 0.038
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B04.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B05": {
+      "title": "Band 5",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B05",
+          "center_wavelength": 0.7039,
+          "full_width_half_max": 0.019
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B05.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B06": {
+      "title": "Band 6",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B06",
+          "center_wavelength": 0.7402,
+          "full_width_half_max": 0.018
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B06.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B07": {
+      "title": "Band 7",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B07",
+          "center_wavelength": 0.7825,
+          "full_width_half_max": 0.028
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B07.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B08": {
+      "title": "Band 8 (nir)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 10,
+      "eo:bands": [
+        {
+          "name": "B08",
+          "common_name": "nir",
+          "center_wavelength": 0.8351,
+          "full_width_half_max": 0.145
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B08.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B8A": {
+      "title": "Band 8A",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B8A",
+          "center_wavelength": 0.8648,
+          "full_width_half_max": 0.033
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B8A.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B09": {
+      "title": "Band 9",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 60,
+      "eo:bands": [
+        {
+          "name": "B09",
+          "center_wavelength": 0.945,
+          "full_width_half_max": 0.026
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B09.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        199980.0,
+        0.0,
+        -60.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B11": {
+      "title": "Band 11 (swir16)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B11",
+          "common_name": "swir16",
+          "center_wavelength": 1.6137,
+          "full_width_half_max": 0.143
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B11.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "B12": {
+      "title": "Band 12 (swir22)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "gsd": 20,
+      "eo:bands": [
+        {
+          "name": "B12",
+          "common_name": "swir22",
+          "center_wavelength": 2.22024,
+          "full_width_half_max": 0.242
+        }
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/B12.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "AOT": {
+      "title": "Aerosol Optical Thickness (AOT)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/AOT.tif",
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        199980.0,
+        0.0,
+        -60.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "WVP": {
+      "title": "Water Vapour (WVP)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/WVP.tif",
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        199980.0,
+        0.0,
+        -10.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "SCL": {
+      "title": "Scene Classification Map (SCL)",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data"
+      ],
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/SCL.tif",
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        199980.0,
+        0.0,
+        -20.0,
+        2700000.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/S2B_35QKG_20230603_0_L2A.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "canonical",
+      "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/S2B_35QKG_20230603_0_L2A.json",
+      "type": "application/json"
+    },
+    {
+      "title": "sentinel-s2-l2a-aws/workflow-publish-sentinel/tiles-35-Q-KG-2023-6-3-0",
+      "rel": "via-cirrus",
+      "href": "https://cirrus-earth-search.aws.element84.com/v0/catid/sentinel-s2-l2a-aws/workflow-publish-sentinel/tiles-35-Q-KG-2023-6-3-0"
+    },
+    {
+      "title": "Source STAC Item",
+      "rel": "derived_from",
+      "href": "https://cirrus-v0-data-1qm7gekzjucbq.s3.us-west-2.amazonaws.com/sentinel-s2-l2a/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/S2B_35QKG_20230603_0_L2A.json",
+      "type": "application/json"
+    },
+    {
+      "title": "sentinel-s2-l2a/workflow-cog-archive/S2B_35QKG_20230603_0_L2A",
+      "rel": "via-cirrus",
+      "href": "https://cirrus-earth-search.aws.element84.com/v0/catid/sentinel-s2-l2a/workflow-cog-archive/S2B_35QKG_20230603_0_L2A"
+    }
+  ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -330,6 +330,8 @@ sqlalchemy==1.4.43
     # via
     #   datacube
     #   geoalchemy2
+stac-sentinel @ git+https://github.com/stac-utils/stac-sentinel@5cef8ac88f403e9d1879059dd5a9295ef190897b
+    # via git
 tblib==1.7.0
     # via distributed
 tifffile==2022.10.10


### PR DESCRIPTION
Updating the gap-filler script to handle changes in metadata from the provider. The whole sentinel-2 indexing process is based off of consistent metadata that is provided in SNS messages from the provider. These messaged are ephemeral, meaning if product indexing fails, the messages must be recreated using the gap-filler script. Changes in provider source metadata means this script no longer worked. Fixes have been made and the script must be robust to changes (however it may break in the future). See examples below for variations of source stac metadata for different scenes, and the stac metadata required in the SNS messages:

Provided Examples
- https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/35/Q/KG/2023/6/S2B_35QKG_20230603_0_L2A/S2B_35QKG_20230603_0_L2A.json
- https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/M/TT/2019/3/S2A_33MTT_20190327_0_L2A/S2A_33MTT_20190327_0_L2A.json

Target for indexing
- https://deafrica-sentinel-2.s3.af-south-1.amazonaws.com/sentinel-s2-l2a-cogs/31/P/ER/2024/5/S2B_31PER_20240522_0_L2A/S2B_31PER_20240522_0_L2A.json