### PR TITLE
Add Kubecost allocation fields to sandbox weekly cost report

### DIFF
--- a/deafrica/platform/sandbox_weekly_cost_report.py
+++ b/deafrica/platform/sandbox_weekly_cost_report.py
@@ -16,6 +16,8 @@ DEFAULT_KUBECOST_URL = "http://kubecost-cost-analyzer.kubecost.svc.cluster.local
 DEFAULT_REPORT_PATH = "/tmp/sandbox_weekly_cost_report.csv"
 GOOGLE_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 CSV_MIME_TYPE = "text/csv"
+# Kubecost returns RAM/PV sizes in bytes; report them in GiB for readability.
+BYTES_PER_GIB = 1024**3
 
 
 def report_date():
@@ -65,6 +67,18 @@ def accumulated_data(response):
 
 def cost(value):
     return float(value or 0.0)
+
+
+def gib(value):
+    return cost(value) / BYTES_PER_GIB
+
+
+def pv_claims(pvs):
+    if not isinstance(pvs, dict):
+        return ""
+
+    # Kubecost exposes PV allocations as a map keyed by claim/PV identity.
+    return ";".join(sorted(str(claim) for claim in pvs.keys()))
 
 
 def node_asset_key(asset_key, asset):
@@ -159,6 +173,8 @@ def write_report(
 
         node_name = properties.get("node", "")
         node_asset = find_node_asset(node_name, node_assets, node_index)
+        pod_runtime_hours = cost(pod_data.get("minutes")) / 60
+        pod_total_cost = cost(pod_data.get("totalCost"))
 
         rows.append(
             {
@@ -167,7 +183,7 @@ def write_report(
                 "node_name": node_name,
                 "pod_allocation_start": pod_data.get("start", ""),
                 "pod_allocation_end": pod_data.get("end", ""),
-                "pod_runtime_hours": round(cost(pod_data.get("minutes")) / 60, 2),
+                "pod_runtime_hours": round(pod_runtime_hours, 2),
                 "node_start": (node_asset or {}).get("start", ""),
                 "node_end": (node_asset or {}).get("end", ""),
                 "total_node_runtime_hours": round(
@@ -178,7 +194,28 @@ def write_report(
                 "total_instance_cost": round(
                     cost((node_asset or {}).get("totalCost")), 4
                 ),
-                "pod_total_cost": round(cost(pod_data.get("totalCost")), 4),
+                "pod_total_cost": round(pod_total_cost, 4),
+                # Additional Allocation API fields for pod size, usage, and PV cost.
+                "pod_avg_cpu_requested_cores": round(
+                    cost(pod_data.get("cpuCoreRequestAverage")), 4
+                ),
+                "pod_avg_cpu_used_cores": round(
+                    cost(pod_data.get("cpuCoreUsageAverage")), 4
+                ),
+                "pod_cpu_cost": round(cost(pod_data.get("cpuCost")), 4),
+                "pod_avg_memory_requested_gib": round(
+                    gib(pod_data.get("ramByteRequestAverage")), 4
+                ),
+                "pod_avg_memory_used_gib": round(
+                    gib(pod_data.get("ramByteUsageAverage")), 4
+                ),
+                "pod_memory_cost": round(cost(pod_data.get("ramCost")), 4),
+                "pod_pvc_storage_avg_gib": round(gib(pod_data.get("pvBytes")), 4),
+                "pod_pvc_storage_gib_hours": round(
+                    gib(pod_data.get("pvByteHours")), 4
+                ),
+                "pod_pvc_storage_cost": round(cost(pod_data.get("pvCost")), 4),
+                "pod_pvc_claims": pv_claims(pod_data.get("pvs")),
             }
         )
 
@@ -196,6 +233,16 @@ def write_report(
         "node_provider_id",
         "total_instance_cost",
         "pod_total_cost",
+        "pod_avg_cpu_requested_cores",
+        "pod_avg_cpu_used_cores",
+        "pod_cpu_cost",
+        "pod_avg_memory_requested_gib",
+        "pod_avg_memory_used_gib",
+        "pod_memory_cost",
+        "pod_pvc_storage_avg_gib",
+        "pod_pvc_storage_gib_hours",
+        "pod_pvc_storage_cost",
+        "pod_pvc_claims",
     ]
 
     with open(report_path, "w", newline="") as report:

--- a/deafrica/platform/sandbox_weekly_cost_report.py
+++ b/deafrica/platform/sandbox_weekly_cost_report.py
@@ -211,9 +211,7 @@ def write_report(
                 ),
                 "pod_memory_cost": round(cost(pod_data.get("ramCost")), 4),
                 "pod_pvc_storage_avg_gib": round(gib(pod_data.get("pvBytes")), 4),
-                "pod_pvc_storage_gib_hours": round(
-                    gib(pod_data.get("pvByteHours")), 4
-                ),
+                "pod_pvc_storage_gib_hours": round(gib(pod_data.get("pvByteHours")), 4),
                 "pod_pvc_storage_cost": round(cost(pod_data.get("pvCost")), 4),
                 "pod_pvc_claims": pv_claims(pod_data.get("pvs")),
             }

--- a/deafrica/tests/test_sandbox_weekly_cost_report.py
+++ b/deafrica/tests/test_sandbox_weekly_cost_report.py
@@ -1,0 +1,66 @@
+import csv
+
+from deafrica.platform.sandbox_weekly_cost_report import write_report
+
+
+def test_write_report_includes_allocation_average_and_storage_fields(tmp_path):
+    report_path = tmp_path / "sandbox_weekly_cost_report.csv"
+    allocation = {
+        "sandbox/jupyter-user/ip-10-0-0-1": {
+            "properties": {
+                "namespace": "sandbox",
+                "pod": "jupyter-user",
+                "node": "ip-10-0-0-1",
+            },
+            "start": "2026-06-01T00:00:00Z",
+            "end": "2026-06-01T02:00:00Z",
+            "minutes": 120,
+            "totalCost": 4.0,
+            "cpuCoreRequestAverage": 1.2,
+            "cpuCoreUsageAverage": 0.05,
+            "cpuCost": 1.25,
+            "ramByteRequestAverage": 2 * 1024**3,
+            "ramByteUsageAverage": 512 * 1024**2,
+            "ramCost": 2.5,
+            "pvBytes": 10 * 1024**3,
+            "pvByteHours": 20 * 1024**3,
+            "pvCost": 0.25,
+            "pvs": {
+                "claim-user": {},
+                "shared-data": {},
+            },
+        }
+    }
+    node_assets = [
+        {
+            "_asset_key": "ip-10-0-0-1",
+            "type": "node",
+            "name": "ip-10-0-0-1",
+            "minutes": 120,
+            "totalCost": 8.0,
+            "properties": {
+                "providerID": "aws:///af-south-1c/i-1234567890",
+                "instanceType": "m6i.xlarge",
+            },
+        }
+    ]
+    node_index = {"ip-10-0-0-1": node_assets[0]}
+
+    row_count = write_report(
+        report_path, allocation, node_assets, node_index, "sandbox", "jupyter-"
+    )
+
+    with open(report_path, newline="") as report:
+        rows = list(csv.DictReader(report))
+
+    assert row_count == 1
+    assert rows[0]["pod_avg_cpu_requested_cores"] == "1.2"
+    assert rows[0]["pod_avg_cpu_used_cores"] == "0.05"
+    assert rows[0]["pod_cpu_cost"] == "1.25"
+    assert rows[0]["pod_avg_memory_requested_gib"] == "2.0"
+    assert rows[0]["pod_avg_memory_used_gib"] == "0.5"
+    assert rows[0]["pod_memory_cost"] == "2.5"
+    assert rows[0]["pod_pvc_storage_avg_gib"] == "10.0"
+    assert rows[0]["pod_pvc_storage_gib_hours"] == "20.0"
+    assert rows[0]["pod_pvc_storage_cost"] == "0.25"
+    assert rows[0]["pod_pvc_claims"] == "claim-user;shared-data"


### PR DESCRIPTION
Adds additional Kubecost Allocation API fields to the Sandbox weekly cost report so the CSV includes average CPU, memory, and PVC storage cost/size information.
