### PR TITLE
Fix country names in sandbox users report

### DIFF
--- a/deafrica/platform/sandbox_cognito_userpool_report.py
+++ b/deafrica/platform/sandbox_cognito_userpool_report.py
@@ -10,14 +10,16 @@ import boto3
 import click
 import pandas as pd
 import phonenumbers
+from babel import Locale
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from phonenumbers import NumberParseException, geocoder
+from phonenumbers import NumberParseException
 
 DEFAULT_SENDER_EMAIL = "info@digitalearthafrica.org"
 GOOGLE_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ENGLISH_LOCALE = Locale.parse("en")
 REPORT_COLUMNS = [
     "Username",
     "email",
@@ -56,7 +58,14 @@ def phone_number_country(phone_number):
     except NumberParseException:
         return ""
 
-    return geocoder.country_name_for_number(parsed_number, "en") or ""
+    if not phonenumbers.is_valid_number(parsed_number):
+        return ""
+
+    region_code = phonenumbers.region_code_for_number(parsed_number)
+    if not region_code or region_code == "001":
+        return ""
+
+    return ENGLISH_LOCALE.territories.get(region_code, "")
 
 
 def report_environment(environment):

--- a/deafrica/tests/test_sandbox_cognito_userpool_report.py
+++ b/deafrica/tests/test_sandbox_cognito_userpool_report.py
@@ -30,6 +30,18 @@ def test_users_to_dataframe_handles_missing_attributes():
 def test_phone_number_country_handles_invalid_values():
     assert report.phone_number_country("") == ""
     assert report.phone_number_country("not a phone number") == ""
+    assert report.phone_number_country("+254000000000") == ""
+
+
+def test_phone_number_country_returns_full_country_names():
+    assert report.phone_number_country("+254712345678") == "Kenya"
+    assert report.phone_number_country("+61412345678") == "Australia"
+    assert report.phone_number_country("+79161234567") == "Russia"
+    assert report.phone_number_country("+447911123456") == "Guernsey"
+
+
+def test_phone_number_country_ignores_non_geographic_numbers():
+    assert report.phone_number_country("+80012345678") == ""
 
 
 class FakePaginator:

--- a/deafrica/tests/test_sandbox_cognito_userpool_report.py
+++ b/deafrica/tests/test_sandbox_cognito_userpool_report.py
@@ -44,20 +44,6 @@ def test_phone_number_country_ignores_non_geographic_numbers():
     assert report.phone_number_country("+80012345678") == ""
 
 
-def test_phone_number_country_falls_back_to_region_code(monkeypatch):
-    monkeypatch.setattr(
-        report.geocoder,
-        "country_name_for_number",
-        lambda *_args: "",
-    )
-    monkeypatch.setattr(
-        report.phonenumbers,
-        "region_code_for_number",
-        lambda _parsed_number: "XX",
-    )
-
-    assert report.phone_number_country("+254700000000") == "XX"
-
 
 class FakePaginator:
     def __init__(self, operation_name):

--- a/deafrica/tests/test_sandbox_cognito_userpool_report.py
+++ b/deafrica/tests/test_sandbox_cognito_userpool_report.py
@@ -44,7 +44,6 @@ def test_phone_number_country_ignores_non_geographic_numbers():
     assert report.phone_number_country("+80012345678") == ""
 
 
-
 class FakePaginator:
     def __init__(self, operation_name):
         self.operation_name = operation_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,8 @@ azure-identity==1.25.1
     # via adlfs
 azure-storage-blob==12.28.0
     # via adlfs
+babel==2.17.0
+    # via deafrica (setup.py)
 bcrypt==5.0.0
     # via paramiko
 beautifulsoup4==4.14.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ packages = find_namespace:
 python_requires = >=3.6
 install_requires =
     aiohttp>=3.12.14
+    babel
     boto3
     click
     cdsapi>=0.7.4


### PR DESCRIPTION
Validates the phone number.
Determines its ISO region code, such as KE, AU, or RU.
Uses Babel to convert the code into Kenya, Australia, or Russia.