### PR TITLE
Add latest report upload and phone validation status

### DIFF
--- a/deafrica/platform/sandbox_cognito_userpool_report.py
+++ b/deafrica/platform/sandbox_cognito_userpool_report.py
@@ -25,6 +25,7 @@ REPORT_COLUMNS = [
     "email",
     "phone_number",
     "phone_number_country",
+    "phone_number_validation_status",
     "given_name",
     "family_name",
     "custom:organisation",
@@ -48,24 +49,38 @@ REPORT_COLUMNS = [
 current_date = datetime.now().strftime("%Y-%m-%d")
 
 
-def phone_number_country(phone_number):
+def phone_number_details(phone_number):
     phone_number = str(phone_number or "").strip()
     if not phone_number:
-        return ""
+        return "", "missing"
 
     try:
         parsed_number = phonenumbers.parse(phone_number, None)
     except NumberParseException:
-        return ""
+        return "", "unparseable"
 
-    if not phonenumbers.is_valid_number(parsed_number):
-        return ""
-
+    # Resolve the country before validating the subscriber number so a malformed
+    # number can still be associated with its recognized calling-code country.
     region_code = phonenumbers.region_code_for_number(parsed_number)
     if not region_code or region_code == "001":
-        return ""
+        return "", "unknown country"
 
-    return ENGLISH_LOCALE.territories.get(region_code, "")
+    country = ENGLISH_LOCALE.territories.get(region_code, "")
+    if not country:
+        return "", "unknown country"
+
+    if not phonenumbers.is_possible_number(parsed_number):
+        return country, "invalid length"
+
+    if not phonenumbers.is_valid_number(parsed_number):
+        return country, "invalid number"
+
+    return country, "valid"
+
+
+def phone_number_country(phone_number):
+    country, _ = phone_number_details(phone_number)
+    return country
 
 
 def report_environment(environment):
@@ -126,7 +141,10 @@ def users_to_dataframe(users):
             if attr.get("Name"):
                 base[attr["Name"]] = attr.get("Value", "")
 
-        base["phone_number_country"] = phone_number_country(base.get("phone_number"))
+        (
+            base["phone_number_country"],
+            base["phone_number_validation_status"],
+        ) = phone_number_details(base.get("phone_number"))
         records.append(base)
 
     df = pd.DataFrame(records)
@@ -210,8 +228,40 @@ def send_email_with_attachment(recipient_email, report_path, sender_email, ses_c
         print(f"Error sending email via SES: {e}")
 
 
+def find_report_in_google_drive(service, report_name, google_drive_folder_id):
+    response = (
+        service.files()
+        .list(
+            q=(
+                f"name = '{report_name}' and "
+                f"'{google_drive_folder_id}' in parents and trashed = false"
+            ),
+            spaces="drive",
+            fields="files(id, webViewLink)",
+            pageSize=2,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+        )
+        .execute()
+    )
+    files = response.get("files", [])
+
+    # The stable "latest" report must identify exactly one Drive file to update.
+    if len(files) > 1:
+        raise ValueError(
+            f"Multiple Google Drive files named {report_name!r} exist in the "
+            "configured folder"
+        )
+
+    return files[0] if files else None
+
+
 def upload_report_to_google_drive(
-    report_path, report_name, google_drive_folder_id, google_credentials_file
+    report_path,
+    report_name,
+    google_drive_folder_id,
+    google_credentials_file,
+    overwrite_existing=False,
 ):
     if not google_drive_folder_id:
         raise ValueError("GOOGLE_DRIVE_FOLDER_ID is required for Google Drive upload")
@@ -233,24 +283,45 @@ def upload_report_to_google_drive(
     )
     service = build("drive", "v3", credentials=credentials, cache_discovery=False)
 
-    file_metadata = {
-        "name": report_name,
-        "parents": [google_drive_folder_id],
-    }
     media = MediaFileUpload(report_path, mimetype=XLSX_MIME_TYPE, resumable=False)
 
-    uploaded_file = (
-        service.files()
-        .create(
-            body=file_metadata,
-            media_body=media,
-            fields="id, webViewLink",
-            supportsAllDrives=True,
+    existing_file = None
+    if overwrite_existing:
+        existing_file = find_report_in_google_drive(
+            service,
+            report_name,
+            google_drive_folder_id,
         )
-        .execute()
-    )
 
-    print(f"Uploaded report to Google Drive file id {uploaded_file.get('id')}")
+    if existing_file:
+        uploaded_file = (
+            service.files()
+            .update(
+                fileId=existing_file["id"],
+                media_body=media,
+                fields="id, webViewLink",
+                supportsAllDrives=True,
+            )
+            .execute()
+        )
+        action = "Updated"
+    else:
+        uploaded_file = (
+            service.files()
+            .create(
+                body={
+                    "name": report_name,
+                    "parents": [google_drive_folder_id],
+                },
+                media_body=media,
+                fields="id, webViewLink",
+                supportsAllDrives=True,
+            )
+            .execute()
+        )
+        action = "Uploaded"
+
+    print(f"{action} report in Google Drive file id {uploaded_file.get('id')}")
     print(f"Google Drive report link: {uploaded_file.get('webViewLink')}")
     return uploaded_file
 
@@ -268,6 +339,7 @@ def main(
     environment = report_environment(environment)
     environment_suffix = f"_{environment}" if environment else ""
     report_name = f"Users{environment_suffix}_{current_date}.xlsx"
+    latest_report_name = f"Users{environment_suffix}_latest.xlsx"
     report_path = report_name
 
     cognito_client = boto3.client("cognito-idp", region_name=aws_region_cognito)
@@ -278,7 +350,7 @@ def main(
     write_excel_report(report_path, df)
 
     if email_address:
-        print(f"Sending email with attached Excel report...")
+        print("Sending email with attached Excel report...")
         ses_client = boto3.client("ses", region_name=aws_region_ses)
         send_email_with_attachment(
             email_address,
@@ -289,12 +361,26 @@ def main(
     else:
         print("Skipping email because no recipient email address was provided")
 
-    if google_drive_folder_id or google_credentials_file:
+    if google_drive_folder_id and google_credentials_file:
+        # Keep the dated upload as an archive and a stable file for consumers
+        # that always need the most recent report.
         upload_report_to_google_drive(
             report_path,
             report_name,
             google_drive_folder_id,
             google_credentials_file,
+        )
+        upload_report_to_google_drive(
+            report_path,
+            latest_report_name,
+            google_drive_folder_id,
+            google_credentials_file,
+            overwrite_existing=True,
+        )
+    elif google_drive_folder_id or google_credentials_file:
+        raise ValueError(
+            "Both GOOGLE_DRIVE_FOLDER_ID and "
+            "GOOGLE_APPLICATION_CREDENTIALS are required"
         )
     else:
         print("Skipping Google Drive upload")

--- a/deafrica/tests/test_sandbox_cognito_userpool_report.py
+++ b/deafrica/tests/test_sandbox_cognito_userpool_report.py
@@ -1,4 +1,7 @@
+from unittest.mock import MagicMock
+
 import pandas as pd
+import pytest
 
 from deafrica.platform import sandbox_cognito_userpool_report as report
 
@@ -24,24 +27,41 @@ def test_users_to_dataframe_handles_missing_attributes():
     assert list(df.columns) == report.REPORT_COLUMNS
     assert row["email"] == "alice@example.com"
     assert row["phone_number_country"] == "Kenya"
+    assert row["phone_number_validation_status"] == "valid"
     assert row["custom:timeframe"] == ""
 
 
-def test_phone_number_country_handles_invalid_values():
-    assert report.phone_number_country("") == ""
-    assert report.phone_number_country("not a phone number") == ""
-    assert report.phone_number_country("+254000000000") == ""
+def test_phone_number_details_handles_missing_and_unparseable_values():
+    assert report.phone_number_details("") == ("", "missing")
+    assert report.phone_number_details(None) == ("", "missing")
+    assert report.phone_number_details("not a phone number") == ("", "unparseable")
+    assert report.phone_number_details("+99912345") == ("", "unparseable")
 
 
 def test_phone_number_country_returns_full_country_names():
-    assert report.phone_number_country("+254712345678") == "Kenya"
-    assert report.phone_number_country("+61412345678") == "Australia"
-    assert report.phone_number_country("+79161234567") == "Russia"
-    assert report.phone_number_country("+447911123456") == "Guernsey"
+    assert report.phone_number_details("+254712345678") == ("Kenya", "valid")
+    assert report.phone_number_details("+61412345678") == ("Australia", "valid")
+    assert report.phone_number_details("+79161234567") == ("Russia", "valid")
+    assert report.phone_number_details("+447911123456") == ("Guernsey", "valid")
+
+
+def test_phone_number_details_preserves_country_for_invalid_numbers():
+    assert report.phone_number_details("+22178298515") == (
+        "Senegal",
+        "invalid length",
+    )
+    assert report.phone_number_details("+254000000000") == (
+        "Kenya",
+        "invalid number",
+    )
 
 
 def test_phone_number_country_ignores_non_geographic_numbers():
-    assert report.phone_number_country("+80012345678") == ""
+    assert report.phone_number_details("+80012345678") == ("", "unknown country")
+
+
+def test_phone_number_country_remains_available_for_existing_callers():
+    assert report.phone_number_country("+22178298515") == "Senegal"
 
 
 class FakePaginator:
@@ -74,3 +94,115 @@ def test_add_user_groups_adds_group_columns_in_memory():
     assert result.loc[1, "admins"] == ""
     assert result.loc[0, "users"] == "users"
     assert result.loc[1, "users"] == "users"
+
+
+def mock_google_drive(monkeypatch, tmp_path, existing_files):
+    credentials_file = tmp_path / "credentials.json"
+    credentials_file.write_text("{}")
+
+    service = MagicMock()
+    files = service.files.return_value
+    files.list.return_value.execute.return_value = {"files": existing_files}
+    upload_result = {"id": "file-id", "webViewLink": "https://drive.example/report"}
+    files.create.return_value.execute.return_value = upload_result
+    files.update.return_value.execute.return_value = upload_result
+
+    monkeypatch.setattr(
+        report.service_account.Credentials,
+        "from_service_account_file",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(report, "build", lambda *args, **kwargs: service)
+    monkeypatch.setattr(report, "MediaFileUpload", MagicMock())
+
+    return str(credentials_file), files
+
+
+def upload_latest(credentials_file):
+    return report.upload_report_to_google_drive(
+        "Users_prod_2026-06-15.xlsx",
+        "Users_prod_latest.xlsx",
+        "drive-folder-id",
+        credentials_file,
+        overwrite_existing=True,
+    )
+
+
+def mock_report_generation(monkeypatch):
+    monkeypatch.setattr(report, "required_env", lambda name: "test-value")
+    monkeypatch.setattr(report.boto3, "client", lambda *args, **kwargs: object())
+    monkeypatch.setattr(report, "fetch_users_from_cognito", lambda *args: [])
+    monkeypatch.setattr(report, "add_user_groups", lambda df, *args: df)
+    monkeypatch.setattr(report, "write_excel_report", lambda *args: None)
+
+
+@pytest.mark.parametrize(
+    ("existing_files", "method", "unused_method"),
+    [
+        ([], "create", "update"),
+        ([{"id": "existing-file-id"}], "update", "create"),
+    ],
+)
+def test_upload_creates_or_updates_latest_report(
+    monkeypatch, tmp_path, existing_files, method, unused_method
+):
+    credentials_file, files = mock_google_drive(monkeypatch, tmp_path, existing_files)
+    upload_latest(credentials_file)
+
+    upload = getattr(files, method)
+    upload.assert_called_once()
+    getattr(files, unused_method).assert_not_called()
+    if method == "create":
+        assert upload.call_args.kwargs["body"]["name"] == "Users_prod_latest.xlsx"
+    else:
+        assert upload.call_args.kwargs["fileId"] == "existing-file-id"
+
+
+@pytest.mark.parametrize(
+    ("environment", "latest_report_name"),
+    [
+        ("dev", "Users_dev_latest.xlsx"),
+        ("prod", "Users_prod_latest.xlsx"),
+    ],
+)
+def test_main_uploads_archive_and_environment_latest_report(
+    monkeypatch, environment, latest_report_name
+):
+    mock_report_generation(monkeypatch)
+    uploads = []
+    monkeypatch.setattr(
+        report,
+        "upload_report_to_google_drive",
+        lambda *args, **kwargs: uploads.append((args, kwargs)),
+    )
+
+    report.main(
+        email_address=None,
+        google_drive_folder_id="drive-folder-id",
+        google_credentials_file="credentials.json",
+        environment=environment,
+    )
+
+    dated_report = f"Users_{environment}_{report.current_date}.xlsx"
+    assert [args[0] for args, _ in uploads] == [dated_report, dated_report]
+    assert [(args[1], kwargs) for args, kwargs in uploads] == [
+        (dated_report, {}),
+        (latest_report_name, {"overwrite_existing": True}),
+    ]
+
+
+def test_upload_rejects_duplicate_latest_reports(monkeypatch, tmp_path):
+    credentials_file, files = mock_google_drive(
+        monkeypatch,
+        tmp_path,
+        [{"id": "first-file-id"}, {"id": "second-file-id"}],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Multiple Google Drive files named 'Users_prod_latest.xlsx'",
+    ):
+        upload_latest(credentials_file)
+
+    files.create.assert_not_called()
+    files.update.assert_not_called()


### PR DESCRIPTION
Added phone-number validation status to the Cognito users report.
Preserve identifiable countries for invalid phone numbers.
Upload a dated report for historical archiving.
Create or update an environment-specific latest report in Google Drive.