### PR TITLE
Add safe CloudFerro source cleanup after sync

### DIFF
--- a/deafrica/data/cdse_pipelines/sentinel_sync_cloudferro.py
+++ b/deafrica/data/cdse_pipelines/sentinel_sync_cloudferro.py
@@ -63,6 +63,7 @@ DEFAULT_CLOUDFERRO_REGION = "RegionOne"
 DEFAULT_DRY_RUN = False
 DEFAULT_MIN_OBJECT_AGE_MINUTES = 60
 DEFAULT_MAX_WORKERS = 4
+DELETE_OBJECT_BATCH_SIZE = 1000
 DEFAULT_INVALID_OBJECT_EXAMPLE_LIMIT = 10
 DEFAULT_CDSE_BATCH_PROCESS_URL = (
     "https://sh.dataspace.copernicus.eu/api/v2/batch/process"
@@ -86,6 +87,9 @@ SYNC_COUNTER_FIELDS = (
     "skipped_matching",
     "skipped_mismatched",
     "failed",
+    "would_delete_source_objects",
+    "deleted_source_objects",
+    "source_delete_failed",
 )
 
 log = setup_logging()
@@ -127,6 +131,7 @@ class SyncConfig:
     cloudferro_region: str
     cdse_batch_process_url: str
     cdse_token_url: str
+    delete_source_after_sync: bool = False
 
 
 def product_spec_for_name(name: str) -> ProductSyncSpec:
@@ -294,6 +299,12 @@ def sync_prefix(config: SyncConfig, product: ProductSyncSpec = None) -> dict:
         "skipped_mismatched": 0,
         "failed": 0,
         "failures": [],
+        "delete_source_after_sync": config.delete_source_after_sync,
+        "source_delete_skip_reason": None,
+        "would_delete_source_objects": 0,
+        "deleted_source_objects": 0,
+        "source_delete_failed": 0,
+        "source_delete_failures": [],
     }
 
     if config.job_id:
@@ -431,7 +442,120 @@ def sync_prefix(config: SyncConfig, product: ProductSyncSpec = None) -> dict:
                 }
             )
 
+    maybe_delete_source_prefix(source_s3, config, summary)
+
     log.info("Sync summary: %s", summary)
+    return summary
+
+
+def maybe_delete_source_prefix(source_s3, config: SyncConfig, summary: dict) -> None:
+    """Delete a CloudFerro source prefix only after a fully clean sync."""
+    if not config.delete_source_after_sync:
+        summary["source_delete_skip_reason"] = "delete_source_after_sync_disabled"
+        return
+
+    skip_reason = source_delete_skip_reason(config, summary)
+    if skip_reason:
+        summary["source_delete_skip_reason"] = skip_reason
+        if skip_reason == "dry_run":
+            summary["would_delete_source_objects"] = count_source_prefix_objects(
+                source_s3,
+                bucket=config.source_bucket,
+                prefix=config.source_prefix,
+            )
+        log.info(
+            "Skipping CloudFerro source delete for s3://%s/%s: %s",
+            config.source_bucket,
+            config.source_prefix,
+            skip_reason,
+        )
+        return
+
+    delete_summary = delete_source_prefix(
+        source_s3,
+        bucket=config.source_bucket,
+        prefix=config.source_prefix,
+    )
+    summary.update(delete_summary)
+
+
+def source_delete_skip_reason(config: SyncConfig, summary: dict) -> str | None:
+    if summary.get("skip_reason"):
+        return summary["skip_reason"]
+    if not summary.get("ready_to_sync", False):
+        return "source_not_ready"
+    if summary.get("failed", 0):
+        return "sync_failed"
+    if summary.get("skipped_mismatched", 0):
+        return "skipped_mismatched"
+    if summary.get("skipped_unexpected", 0):
+        return "skipped_unexpected"
+    if summary.get("copyable", 0) == 0:
+        return "no_copyable_objects"
+    synced_objects = summary.get("copied", 0) + summary.get("skipped_matching", 0)
+    if synced_objects != summary.get("copyable", 0):
+        return "sync_not_complete"
+    if config.dry_run:
+        return "dry_run"
+
+    return None
+
+
+def count_source_prefix_objects(source_s3, bucket: str, prefix: str) -> int:
+    return sum(1 for _ in list_source_objects(source_s3, bucket, prefix))
+
+
+def delete_source_prefix(source_s3, bucket: str, prefix: str) -> dict:
+    summary = {
+        "deleted_source_objects": 0,
+        "source_delete_failed": 0,
+        "source_delete_failures": [],
+    }
+    batch = []
+
+    def flush_batch() -> None:
+        if not batch:
+            return
+
+        objects = list(batch)
+        batch.clear()
+        log.info(
+            "Deleting %s CloudFerro source object(s) under s3://%s/%s",
+            len(objects),
+            bucket,
+            prefix,
+        )
+
+        try:
+            response = source_s3.delete_objects(
+                Bucket=bucket,
+                Delete={"Objects": objects, "Quiet": True},
+            )
+        except ClientError as err:
+            error = format_client_error(err)
+            summary["source_delete_failed"] += len(objects)
+            summary["source_delete_failures"].extend(
+                {"source_key": obj["Key"], "error": error} for obj in objects
+            )
+            return
+
+        errors = response.get("Errors", [])
+        summary["deleted_source_objects"] += len(objects) - len(errors)
+        summary["source_delete_failed"] += len(errors)
+        summary["source_delete_failures"].extend(
+            {
+                "source_key": error.get("Key"),
+                "error": error.get("Message") or error.get("Code") or "delete_failed",
+            }
+            for error in errors
+        )
+
+    for source_object in list_source_objects(source_s3, bucket, prefix):
+        batch.append({"Key": source_object["Key"]})
+        if len(batch) == DELETE_OBJECT_BATCH_SIZE:
+            flush_batch()
+
+    flush_batch()
     return summary
 
 
@@ -481,6 +605,7 @@ def sync_all_prefixes(
         "destination_bucket": config.destination_bucket,
         "source_root_prefix": product.discovery_prefix,
         "dry_run": config.dry_run,
+        "delete_source_after_sync": config.delete_source_after_sync,
         "min_object_age_minutes": config.min_object_age_minutes,
         "discovery_prefix": discovery_prefix,
         "max_workers": max_workers,
@@ -1513,6 +1638,16 @@ DEFAULT_PRODUCT_SPEC = S1_RTC_PRODUCT
     help="Report planned copies without uploading objects.",
 )
 @click.option(
+    "--delete-source-after-sync",
+    is_flag=True,
+    default=False,
+    envvar="DELETE_SOURCE_AFTER_SYNC",
+    help=(
+        "Delete the exact CloudFerro source prefix after a fully clean sync. "
+        "Skipped for dry runs, sync failures, mismatches, and incomplete syncs."
+    ),
+)
+@click.option(
     "--min-object-age-minutes",
     default=DEFAULT_MIN_OBJECT_AGE_MINUTES,
     show_default=True,
@@ -1572,6 +1707,7 @@ def cli(
     max_prefixes,
     destination_bucket,
     dry_run,
+    delete_source_after_sync,
     min_object_age_minutes,
     job_id,
     cloudferro_endpoint_url,
@@ -1624,6 +1760,7 @@ def cli(
         cloudferro_region=cloudferro_region,
         cdse_batch_process_url=cdse_batch_process_url,
         cdse_token_url=cdse_token_url,
+        delete_source_after_sync=delete_source_after_sync,
     )
     try:
         if all_prefixes:

--- a/deafrica/tests/test_sentinel_sync_cloudferro.py
+++ b/deafrica/tests/test_sentinel_sync_cloudferro.py
@@ -49,6 +49,7 @@ class FakeCopyS3Client(FakeS3Client):
         super().__init__(objects or [])
         self.bodies = bodies or {}
         self.uploads = []
+        self.deletes = []
 
     def head_object(self, Bucket, Key):
         if Key not in self.bodies:
@@ -70,6 +71,17 @@ class FakeCopyS3Client(FakeS3Client):
         self.bodies[Key] = body.read()
         self.uploads.append(Key)
 
+    def delete_objects(self, Bucket, Delete):
+        deleted = []
+        for obj in Delete["Objects"]:
+            key = obj["Key"]
+            self.deletes.append(key)
+            self.bodies.pop(key, None)
+            self.objects = [source for source in self.objects if source["Key"] != key]
+            deleted.append({"Key": key})
+
+        return {"Deleted": deleted}
+
 
 def source_object(key, size=1):
     return {
@@ -79,20 +91,22 @@ def source_object(key, size=1):
     }
 
 
-def sync_config(source_prefix):
-    return SyncConfig(
-        source_bucket="source-bucket",
-        source_prefix=source_prefix,
-        stac_item="",
-        destination_bucket="destination-bucket",
-        dry_run=False,
-        min_object_age_minutes=0,
-        job_id=None,
-        cloudferro_endpoint_url="https://cloudferro.example",
-        cloudferro_region="RegionOne",
-        cdse_batch_process_url="https://batch.example",
-        cdse_token_url="https://token.example",
-    )
+def sync_config(source_prefix, **overrides):
+    values = {
+        "source_bucket": "source-bucket",
+        "source_prefix": source_prefix,
+        "stac_item": "",
+        "destination_bucket": "destination-bucket",
+        "dry_run": False,
+        "min_object_age_minutes": 0,
+        "job_id": None,
+        "cloudferro_endpoint_url": "https://cloudferro.example",
+        "cloudferro_region": "RegionOne",
+        "cdse_batch_process_url": "https://batch.example",
+        "cdse_token_url": "https://token.example",
+    }
+    values.update(overrides)
+    return SyncConfig(**values)
 
 
 def test_validate_required_files_detects_complete_output():
@@ -465,6 +479,122 @@ def test_s3_direct_copy_refreshes_changed_metadata_but_not_tif(monkeypatch):
     assert destination_s3.uploads == [metadata_key]
     assert destination_s3.bodies[metadata_key] == source_bodies[metadata_key]
     assert destination_s3.bodies[data_key] == destination_bodies[data_key]
+
+
+def test_delete_source_after_clean_direct_copy_sync(monkeypatch):
+    prefix = "s3_wfr_test/2026/02/09/37NBB_0_0/"
+    metadata_key = f"{prefix}S3_OL_2_WFR_20260209_NT_37NBB_0_0_metadata.json"
+    data_key = f"{prefix}CHL_NN.tif"
+    userdata_key = f"{prefix}userdata.json"
+    source_bodies = {
+        metadata_key: b'{"type":"Feature"}',
+        data_key: b"tif-data",
+        userdata_key: b'{"status":"done"}',
+    }
+    source_objects = [
+        source_object(metadata_key, size=len(source_bodies[metadata_key])),
+        source_object(userdata_key, size=len(source_bodies[userdata_key])),
+        source_object(data_key, size=len(source_bodies[data_key])),
+    ]
+    source_s3 = FakeCopyS3Client(source_objects, bodies=source_bodies)
+    destination_s3 = FakeCopyS3Client()
+
+    monkeypatch.setattr(sync_module, "cloudferro_client", lambda _config: source_s3)
+    monkeypatch.setattr(sync_module, "aws_client", lambda: destination_s3)
+
+    summary = sync_module.sync_prefix(
+        sync_config(prefix, delete_source_after_sync=True),
+        product=S3_OLCI_L2_WFR_CDSE_PRODUCT,
+    )
+
+    assert summary["failed"] == 0
+    assert summary["copied"] == 2
+    assert summary["source_delete_skip_reason"] is None
+    assert summary["deleted_source_objects"] == 3
+    assert summary["source_delete_failed"] == 0
+    assert set(source_s3.deletes) == {metadata_key, userdata_key, data_key}
+    assert source_s3.objects == []
+    assert set(destination_s3.uploads) == {metadata_key, data_key}
+
+
+def test_delete_source_after_sync_skips_mismatched_destination(monkeypatch):
+    prefix = "s3_wfr_test/2026/02/09/37NBB_0_0/"
+    metadata_key = f"{prefix}S3_OL_2_WFR_20260209_NT_37NBB_0_0_metadata.json"
+    data_key = f"{prefix}CHL_NN.tif"
+    userdata_key = f"{prefix}userdata.json"
+    source_bodies = {
+        metadata_key: b'{"version":"new"}',
+        data_key: b"new-tif",
+        userdata_key: b'{"status":"done"}',
+    }
+    destination_bodies = {
+        metadata_key: b'{"version":"old"}',
+        data_key: b"old",
+    }
+    source_objects = [
+        source_object(data_key, size=len(source_bodies[data_key])),
+        source_object(metadata_key, size=len(source_bodies[metadata_key])),
+        source_object(userdata_key, size=len(source_bodies[userdata_key])),
+    ]
+    source_s3 = FakeCopyS3Client(source_objects, bodies=source_bodies)
+    destination_s3 = FakeCopyS3Client(bodies=destination_bodies)
+
+    monkeypatch.setattr(sync_module, "cloudferro_client", lambda _config: source_s3)
+    monkeypatch.setattr(sync_module, "aws_client", lambda: destination_s3)
+
+    summary = sync_module.sync_prefix(
+        sync_config(prefix, delete_source_after_sync=True),
+        product=S3_OLCI_L2_WFR_CDSE_PRODUCT,
+    )
+
+    assert summary["failed"] == 0
+    assert summary["copied"] == 1
+    assert summary["skipped_mismatched"] == 1
+    assert summary["source_delete_skip_reason"] == "skipped_mismatched"
+    assert summary["deleted_source_objects"] == 0
+    assert source_s3.deletes == []
+    assert len(source_s3.objects) == 3
+
+
+def test_delete_source_after_sync_dry_run_reports_would_delete(monkeypatch):
+    prefix = "s3_wfr_test/2026/02/09/37NBB_0_0/"
+    metadata_key = f"{prefix}S3_OL_2_WFR_20260209_NT_37NBB_0_0_metadata.json"
+    data_key = f"{prefix}CHL_NN.tif"
+    userdata_key = f"{prefix}userdata.json"
+    source_bodies = {
+        metadata_key: b'{"type":"Feature"}',
+        data_key: b"tif-data",
+        userdata_key: b'{"status":"done"}',
+    }
+    source_objects = [
+        source_object(data_key, size=len(source_bodies[data_key])),
+        source_object(metadata_key, size=len(source_bodies[metadata_key])),
+        source_object(userdata_key, size=len(source_bodies[userdata_key])),
+    ]
+    source_s3 = FakeCopyS3Client(source_objects, bodies=source_bodies)
+    destination_s3 = FakeCopyS3Client(
+        bodies={
+            metadata_key: source_bodies[metadata_key],
+            data_key: source_bodies[data_key],
+        }
+    )
+
+    monkeypatch.setattr(sync_module, "cloudferro_client", lambda _config: source_s3)
+    monkeypatch.setattr(sync_module, "aws_client", lambda: destination_s3)
+
+    summary = sync_module.sync_prefix(
+        sync_config(prefix, delete_source_after_sync=True, dry_run=True),
+        product=S3_OLCI_L2_WFR_CDSE_PRODUCT,
+    )
+
+    assert summary["failed"] == 0
+    assert summary["copied"] == 0
+    assert summary["skipped_matching"] == 2
+    assert summary["source_delete_skip_reason"] == "dry_run"
+    assert summary["would_delete_source_objects"] == 3
+    assert summary["deleted_source_objects"] == 0
+    assert source_s3.deletes == []
+    assert len(source_s3.objects) == 3
 
 
 def test_s3_lfr_discovery_accepts_direct_layout_and_ignores_job_nested_layout():


### PR DESCRIPTION
This supports safe CloudFerro cleanup after CDSE product syncs by treating each completed product prefix as the move unit
- copy/check all copyable objects for a prefix
- delete the exact CloudFerro source prefix only after the prefix is fully clean
- skip deletion for dry runs, sync failures, destination mismatches, unexpected source files, or incomplete syncs
